### PR TITLE
Restore cleanup job in CI/CD pipeline for unused image management

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -60,12 +60,12 @@ jobs:
             -p 1206:3000 \
             veila-server:latest
 
-  # cleanup:
-  #   name: Cleanup
-  #   runs-on: [veila]
-  #   needs: [build, deploy-demo, deploy-production]
-  #   steps:
-  #     - name: Cleanup unused images
-  #       run: |
-  #         docker image prune -f
-  #         docker system prune -f
+  cleanup:
+    name: Cleanup
+    runs-on: [veila]
+    needs: [build, deploy-demo, deploy-production]
+    steps:
+      - name: Cleanup unused images
+        run: |
+          docker image prune -f
+          docker system prune -f


### PR DESCRIPTION
Reintroduce the cleanup job in the CI/CD pipeline to manage unused Docker images effectively.