### PR TITLE
Add update request and detail tables with new fields

### DIFF
--- a/src/common/models/order/index.ts
+++ b/src/common/models/order/index.ts
@@ -5,3 +5,5 @@ export * from '@/common/models/order/orderServiceDetail.model';
 export * from '@/common/models/order/request.model';
 export * from '@/common/models/order/task.model';
 export * from '@/common/models/order/orderAccessoryDetail.model';
+export * from '@/common/models/order/updateRequest.model';
+export * from '@/common/models/order/updateOrderServiceDetail.model';

--- a/src/common/models/order/order.model.ts
+++ b/src/common/models/order/order.model.ts
@@ -120,6 +120,37 @@ export class Order extends Base {
   dueDate: Date;
 
   @Column({
+    name: 'return_date',
+    type: 'date',
+    nullable: true,
+    comment: 'Ngày trả hàng (nếu là đơn thuê)',
+  })
+  @ApiProperty({
+    type: 'string',
+    format: 'date',
+    nullable: true,
+    description: 'Ngày trả hàng (nếu là đơn thuê)',
+    example: '2025-07-15',
+  })
+  returnDate: Date | null;
+
+  @Column({
+    name: 'is_buy_back',
+    type: 'boolean',
+    nullable: false,
+    default: false,
+    comment: 'Cửa hàng có mua lại váy cưới sau khi may cho khách không',
+  })
+  @ApiProperty({
+    type: 'boolean',
+    default: false,
+    nullable: false,
+    description: 'Cửa hàng có mua lại váy cưới sau khi may cho khách không',
+    example: false,
+  })
+  isBuyBack: boolean;
+
+  @Column({
     type: 'decimal',
     precision: 12,
     scale: 2,

--- a/src/common/models/order/request.model.ts
+++ b/src/common/models/order/request.model.ts
@@ -1,5 +1,5 @@
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
-import { Base, User } from '@/common/models';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
+import { Base, UpdateRequest, User } from '@/common/models';
 import { ApiProperty } from '@nestjs/swagger';
 
 export enum RequestStatus {
@@ -85,19 +85,13 @@ export class Request extends Base {
   })
   isPrivate: boolean;
 
-  @Column({
-    type: 'int',
-    unsigned: true,
-    nullable: false,
-    default: 1,
-    comment: 'Phiên bản yêu cầu',
+  @OneToMany(() => UpdateRequest, (updateRequest) => updateRequest.request, {
+    nullable: true,
   })
   @ApiProperty({
-    type: 'integer',
-    minimum: 1,
-    nullable: false,
-    description: 'Phiên bản yêu cầu',
-    example: 1,
+    type: [UpdateRequest],
+    nullable: true,
+    description: 'Danh sách các yêu cầu cập nhật liên quan',
   })
-  version: number;
+  updateRequests: UpdateRequest[] | null;
 }

--- a/src/common/models/order/updateOrderServiceDetail.model.ts
+++ b/src/common/models/order/updateOrderServiceDetail.model.ts
@@ -1,46 +1,38 @@
-import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne } from 'typeorm';
-import { Base, Order, Request, Service, UpdateOrderServiceDetail } from '@/common/models';
+import { Base } from '@/common/models/base.model';
+import { OrderServiceDetail } from '@/common/models/order/orderServiceDetail.model';
+import { UpdateRequest } from '@/common/models/order/updateRequest.model';
 import { ApiProperty } from '@nestjs/swagger';
+import { Column, Entity, JoinColumn, ManyToOne, OneToOne } from 'typeorm';
 
-@Entity('order_service_details')
-export class OrderServiceDetail extends Base {
-  @OneToOne(() => Order, (order) => order.orderServiceDetail, {
+@Entity('update_order_service_details')
+export class UpdateOrderServiceDetail extends Base {
+  @ManyToOne(() => OrderServiceDetail, (orderServiceDetail) => orderServiceDetail.updateOrderServiceDetails, {
     nullable: false,
     onDelete: 'CASCADE',
   })
   @JoinColumn({
-    name: 'order_id',
-    foreignKeyConstraintName: 'fk_order_order_service_detail',
+    name: 'order_service_detail_id',
+    foreignKeyConstraintName: 'fk_order_service_detail_update_order_service_detail',
   })
   @ApiProperty({
-    description: 'Đơn hàng liên quan',
-    type: Order,
+    description: 'Chi tiết dịch vụ đơn hàng liên quan',
+    type: OrderServiceDetail,
   })
-  order: Order;
+  orderServiceDetail: OrderServiceDetail;
 
-  @OneToOne(() => Request)
-  @JoinColumn({
-    name: 'request_id',
-    foreignKeyConstraintName: 'fk_request_order_service_detail',
-  })
-  @ApiProperty({
-    description: 'Yêu cầu dịch vụ liên quan',
-    type: Request,
-  })
-  request: Request;
-
-  @ManyToOne(() => Service, {
+  @OneToOne(() => UpdateRequest, {
     nullable: false,
+    onDelete: 'CASCADE',
   })
   @JoinColumn({
-    name: 'service_id',
-    foreignKeyConstraintName: 'fk_service_order_service_detail',
+    name: 'update_request_id',
+    foreignKeyConstraintName: 'fk_update_request_update_order_service_detail',
   })
   @ApiProperty({
-    description: 'Dịch vụ được đặt',
-    type: Service,
+    description: 'Yêu cầu cập nhật liên quan',
+    type: UpdateRequest,
   })
-  service: Service;
+  updateRequest: UpdateRequest;
 
   @Column({
     type: 'integer',
@@ -367,44 +359,15 @@ export class OrderServiceDetail extends Base {
     unsigned: true,
     nullable: false,
     default: 0,
-    comment: 'Giá dịch vụ tại thời điểm đặt',
+    comment: 'Phí phụ thu cho yêu cầu cập nhật',
   })
   @ApiProperty({
     type: 'number',
     format: 'decimal',
     minimum: 0,
     nullable: false,
-    description: 'Giá dịch vụ tại thời điểm đặt (VNĐ)',
+    description: 'Phí phụ thu cho yêu cầu cập nhật (VNĐ)',
     example: 1500000,
   })
   price: number;
-
-  @Column({
-    type: 'boolean',
-    nullable: false,
-    default: false,
-    comment: 'Dịch vụ đã được đánh giá hay chưa',
-  })
-  @ApiProperty({
-    type: 'boolean',
-    default: false,
-    nullable: false,
-    description: 'Dịch vụ đã được đánh giá hay chưa',
-    example: false,
-  })
-  isRated: boolean;
-
-  @OneToMany(
-    () => UpdateOrderServiceDetail,
-    (updateOrderServiceDetail) => updateOrderServiceDetail.orderServiceDetail,
-    {
-      nullable: true,
-    },
-  )
-  @ApiProperty({
-    type: [UpdateOrderServiceDetail],
-    nullable: true,
-    description: 'Danh sách các yêu cầu cập nhật liên quan',
-  })
-  updateOrderServiceDetails: UpdateOrderServiceDetail[] | null;
 }

--- a/src/common/models/order/updateRequest.model.ts
+++ b/src/common/models/order/updateRequest.model.ts
@@ -1,0 +1,71 @@
+import { Base } from '@/common/models/base.model';
+import { Request } from '@/common/models/order/request.model';
+import { ApiProperty } from '@nestjs/swagger';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+export enum UpdateRequestStatus {
+  PENDING = 'PENDING',
+  ACCEPTED = 'ACCEPTED',
+  REJECTED = 'REJECTED',
+}
+
+@Entity('update_requests')
+export class UpdateRequest extends Base {
+  @ManyToOne(() => Request, (request) => request.updateRequests, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    name: 'request_id',
+    foreignKeyConstraintName: 'fk_request_update_request',
+  })
+  @ApiProperty({
+    description: 'Yêu cầu cập nhật liên quan',
+    type: Request,
+  })
+  request: Request;
+
+  @Column({
+    type: 'varchar',
+    length: 200,
+    nullable: false,
+    comment: 'Tiêu đề yêu cầu',
+  })
+  @ApiProperty({
+    type: 'string',
+    maxLength: 200,
+    nullable: false,
+    description: 'Tiêu đề yêu cầu',
+    example: 'Yêu cầu thiết kế váy cưới',
+  })
+  title: string;
+
+  @Column({
+    type: 'text',
+    nullable: false,
+    comment: 'Mô tả chi tiết yêu cầu',
+  })
+  @ApiProperty({
+    type: 'string',
+    nullable: false,
+    description: 'Mô tả chi tiết yêu cầu',
+    example: 'Tôi muốn thiết kế một chiếc váy cưới theo phong cách cổ điển.',
+  })
+  description: string;
+
+  @Column({
+    type: 'enum',
+    enum: UpdateRequestStatus,
+    default: UpdateRequestStatus.PENDING,
+    nullable: false,
+    comment: 'Trạng thái yêu cầu',
+  })
+  @ApiProperty({
+    enum: UpdateRequestStatus,
+    default: UpdateRequestStatus.PENDING,
+    nullable: false,
+    description: 'Trạng thái yêu cầu',
+    example: UpdateRequestStatus.PENDING,
+  })
+  status: UpdateRequestStatus;
+}

--- a/src/migrations/1752124655971-update_order_field_and_add_update_order_service.ts
+++ b/src/migrations/1752124655971-update_order_field_and_add_update_order_service.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateOrderFieldAndAddUpdateOrderService1752124655971 implements MigrationInterface {
+    name = 'UpdateOrderFieldAndAddUpdateOrderService1752124655971'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX \`IDX_bb9c758dcc60137e56f6fee72f\` ON \`shops\``);
+        await queryRunner.query(`DROP INDEX \`IDX_a18aeabef54c39a7a5a4b4d9aa\` ON \`order_dress_details\``);
+        await queryRunner.query(`DROP INDEX \`IDX_e89260419bc2817dd3edc4cc25\` ON \`order_service_details\``);
+        await queryRunner.query(`CREATE TABLE \`update_requests\` (\`id\` varchar(36) NOT NULL, \`images\` text NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updatedAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`deletedAt\` datetime(6) NULL, \`title\` varchar(200) NOT NULL COMMENT 'Tiêu đề yêu cầu', \`description\` text NOT NULL COMMENT 'Mô tả chi tiết yêu cầu', \`status\` enum ('PENDING', 'ACCEPTED', 'REJECTED') NOT NULL COMMENT 'Trạng thái yêu cầu' DEFAULT 'PENDING', \`request_id\` varchar(36) NOT NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`update_order_service_details\` (\`id\` varchar(36) NOT NULL, \`images\` text NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updatedAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`deletedAt\` datetime(6) NULL, \`high\` int UNSIGNED NULL COMMENT 'Chiều cao của cô dâu', \`weight\` int UNSIGNED NULL COMMENT 'Cân nặng', \`bust\` int UNSIGNED NULL COMMENT 'Vòng ngực', \`waist\` int UNSIGNED NULL COMMENT 'Vòng eo', \`hip\` int UNSIGNED NULL COMMENT 'Vòng mông', \`armpit\` int UNSIGNED NULL COMMENT 'Vòng nách', \`bicep\` int UNSIGNED NULL COMMENT 'Vòng bắp tay', \`neck\` int UNSIGNED NULL COMMENT 'Vòng cổ', \`shoulderWidth\` int UNSIGNED NULL COMMENT 'Chiều rộng vai', \`sleeveLength\` int UNSIGNED NULL COMMENT 'Chiều dài tay', \`backLength\` int UNSIGNED NULL COMMENT 'Chiều dài lưng, từ chân cổ đến eo', \`lowerWaist\` int UNSIGNED NULL COMMENT 'Từ chân ngực đến eo', \`waistToFloor\` int UNSIGNED NULL COMMENT 'Độ dài tùng váy', \`dressStyle\` varchar(200) CHARACTER SET "utf8mb4" COLLATE "utf8mb4_unicode_ci" NULL COMMENT 'Kiểu dáng váy', \`curtainNeckline\` varchar(200) CHARACTER SET "utf8mb4" COLLATE "utf8mb4_unicode_ci" NULL COMMENT 'Dạng cổ váy', \`sleeveStyle\` varchar(200) CHARACTER SET "utf8mb4" COLLATE "utf8mb4_unicode_ci" NULL COMMENT 'Dạng tay váy', \`material\` varchar(200) CHARACTER SET "utf8mb4" COLLATE "utf8mb4_unicode_ci" NULL COMMENT 'Chất liệu', \`color\` varchar(200) CHARACTER SET "utf8mb4" COLLATE "utf8mb4_unicode_ci" NULL COMMENT 'Màu sắc', \`specialElement\` varchar(200) CHARACTER SET "utf8mb4" COLLATE "utf8mb4_unicode_ci" NULL COMMENT 'Yếu tố đặc biệt', \`coverage\` varchar(200) CHARACTER SET "utf8mb4" COLLATE "utf8mb4_unicode_ci" NULL COMMENT 'Độ che phủ', \`description\` varchar(200) CHARACTER SET "utf8mb4" COLLATE "utf8mb4_unicode_ci" NULL COMMENT 'Mô tả thêm', \`price\` decimal(10,2) UNSIGNED NOT NULL COMMENT 'Phí phụ thu cho yêu cầu cập nhật' DEFAULT '0.00', \`order_service_detail_id\` varchar(36) NOT NULL, \`update_request_id\` varchar(36) NOT NULL, UNIQUE INDEX \`REL_870a22184ad38002baeb10c148\` (\`update_request_id\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`ALTER TABLE \`order_service_details\` DROP COLUMN \`version\``);
+        await queryRunner.query(`ALTER TABLE \`requests\` DROP COLUMN \`version\``);
+        await queryRunner.query(`ALTER TABLE \`orders\` ADD \`return_date\` date NULL COMMENT 'Ngày trả hàng (nếu là đơn thuê)'`);
+        await queryRunner.query(`ALTER TABLE \`orders\` ADD \`is_buy_back\` tinyint NOT NULL COMMENT 'Cửa hàng có mua lại váy cưới sau khi may cho khách không' DEFAULT 0`);
+        await queryRunner.query(`ALTER TABLE \`update_requests\` ADD CONSTRAINT \`fk_request_update_request\` FOREIGN KEY (\`request_id\`) REFERENCES \`requests\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`update_order_service_details\` ADD CONSTRAINT \`fk_order_service_detail_update_order_service_detail\` FOREIGN KEY (\`order_service_detail_id\`) REFERENCES \`order_service_details\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`update_order_service_details\` ADD CONSTRAINT \`fk_update_request_update_order_service_detail\` FOREIGN KEY (\`update_request_id\`) REFERENCES \`update_requests\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`update_order_service_details\` DROP FOREIGN KEY \`fk_update_request_update_order_service_detail\``);
+        await queryRunner.query(`ALTER TABLE \`update_order_service_details\` DROP FOREIGN KEY \`fk_order_service_detail_update_order_service_detail\``);
+        await queryRunner.query(`ALTER TABLE \`update_requests\` DROP FOREIGN KEY \`fk_request_update_request\``);
+        await queryRunner.query(`ALTER TABLE \`orders\` DROP COLUMN \`is_buy_back\``);
+        await queryRunner.query(`ALTER TABLE \`orders\` DROP COLUMN \`return_date\``);
+        await queryRunner.query(`ALTER TABLE \`requests\` ADD \`version\` int UNSIGNED NOT NULL COMMENT 'Phiên bản yêu cầu' DEFAULT '1'`);
+        await queryRunner.query(`ALTER TABLE \`order_service_details\` ADD \`version\` int UNSIGNED NOT NULL COMMENT 'Phiên bản dịch vụ' DEFAULT '1'`);
+        await queryRunner.query(`DROP INDEX \`REL_870a22184ad38002baeb10c148\` ON \`update_order_service_details\``);
+        await queryRunner.query(`DROP TABLE \`update_order_service_details\``);
+        await queryRunner.query(`DROP TABLE \`update_requests\``);
+        await queryRunner.query(`CREATE UNIQUE INDEX \`IDX_e89260419bc2817dd3edc4cc25\` ON \`order_service_details\` (\`order_id\`)`);
+        await queryRunner.query(`CREATE UNIQUE INDEX \`IDX_a18aeabef54c39a7a5a4b4d9aa\` ON \`order_dress_details\` (\`order_id\`)`);
+        await queryRunner.query(`CREATE UNIQUE INDEX \`IDX_bb9c758dcc60137e56f6fee72f\` ON \`shops\` (\`user_id\`)`);
+    }
+
+}


### PR DESCRIPTION
Introduce two new tables for update requests and details, along with fields for return date and buy-back status in the order service. This enhances the order management functionality.